### PR TITLE
Adds the ability to write prespecified PREMIS elements into extension nodes

### DIFF
--- a/pypremis/lib.py
+++ b/pypremis/lib.py
@@ -304,6 +304,11 @@ class PremisRecord(object):
             self.add_rights(rights)
         for obj in factory.find_objects():
             self.add_object(obj)
+        # This fixes a weird bug where the premis xmlns was being written twice
+        # in the attributes of the root tag when calling .write_to_file() in
+        # cases where extension nodes contain children that are PremisNodes
+        ET.register_namespace('premis', "")
+        ET.register_namespace('xsi', "")
 
     def write_to_file(self, targetpath):
         """
@@ -324,5 +329,5 @@ class PremisRecord(object):
             root.append(entry.toXML())
         tree.write(targetpath,
                    xml_declaration=True,
-                   encoding='utf-8',
+                   encoding='unicode',
                    method='xml')

--- a/pypremis/nodes.py
+++ b/pypremis/nodes.py
@@ -417,6 +417,9 @@ class ExtensionNode(PremisNode):
                 for x in value.toXML():
                     e.append(x)
                 root.append(e)
+            elif isinstance(value, PremisNode):
+                e = value.toXML()
+                root.append(e)
             elif isinstance(value, list):
                 for entry in value:
                     if isinstance(entry, str):
@@ -428,6 +431,9 @@ class ExtensionNode(PremisNode):
                         for n in entry.toXML():
                             e.append(n)
                         root.append(e)
+                    elif isinstance(entry, PremisNode):
+#                        for n in entry.toXML():
+                        root.append(entry.toXML())
                     else:
                         raise ValueError
             else:


### PR DESCRIPTION
Getting at the information in them is tremendously irritating afterwards though because they are treated like any other uncontrolled namespace used in the extension fields and handled by etrees built in namespace mechanics. Oh well.

closes #5 